### PR TITLE
SA's request to have attendance stats on Dev CoP

### DIFF
--- a/Dev CoP Attendance_2018_2019.csv
+++ b/Dev CoP Attendance_2018_2019.csv
@@ -1,0 +1,19 @@
+Session,Date,Total Attendance,Online,In-room
+Pull Requests + Code Review,Dec-19,98,87,11
+GitFlow,Nov-19,96,89,7
+Outcomes Map,Oct-19,98,91,7
+Moving Control Source to Git,Sep-19,150,131,19
+How the SDS team automated our development environment using Git and Pipelines,Jun-19,120,98,22
+DevOps/GCDevOpsLeague!,May-19,112,86,26
+An Introduction to Entity Framework - The Future of Databases?,Apr-19,120,105,15
+Security is Everybody's Job,Mar-19,88,76,12
+Developer Experience (DX) in IITB,Feb-19,96,78,18
+GC Digital Exchange Program,Jan-19,104,83,21
+Perspectives from FWD50,Dec-18,87,64,29
+Open Sourcing GC Code,Nov-18,131,104,27
+Improving User Experience by making your Apps Accessible,Oct-18,157,114,43
+Season Opener,Sep-18,133,111,22
+TFS Modernization,Jun-18,110,90,20
+Reducing Risk,May-18,198,153,45
+Interoperability & NIEM,Apr-18,111,99,12
+MS Fakes,Mar-18,74,74,


### PR DESCRIPTION
Related to SA-SDS Meetings Trello card "DevCoP: Get total # of attendees per session": https://trello.com/c/jOtlsTGI/57-devcop-get-total-of-attendees-per-session